### PR TITLE
Migrate() instead of EnsureCreated() on db seed

### DIFF
--- a/src/openiddict-test/Migrations/DatabaseInitializer.cs
+++ b/src/openiddict-test/Migrations/DatabaseInitializer.cs
@@ -18,7 +18,7 @@ namespace openiddicttest
 
         public async Task Seed()
         {
-            _context.Database.EnsureCreated();
+            _context.Database.Migrate();
 
             // Add Mvc.Client to the known applications.
             if (_context.Applications.Any())


### PR DESCRIPTION
when you use EnsureCreated(), it doesn't actually run the migrations - so you don't get the migration history table, and the next time someone tries to migrate it tries to apply all the migrations (even the ones that are already there).
