### PR TITLE
Use ASP.NET Core RC2 and aspnet-contrib release packages

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetCiDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="aspnet-contrib" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
   </packageSources>

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-  "projects": [ "src", "test" ]
+  "projects": [ "src" ]
 }

--- a/src/openiddict-test/Program.cs
+++ b/src/openiddict-test/Program.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace openiddicttest
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .AddCommandLine(args)
+                .Build();
+
+            var host = new WebHostBuilder()
+                .ConfigureLogging(options => options.AddConsole())
+                .ConfigureLogging(options => options.AddDebug())
+                .UseConfiguration(configuration)
+                .UseIISIntegration()
+                .UseKestrel()
+                .UseStartup<Startup>()
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/src/openiddict-test/Startup.cs
+++ b/src/openiddict-test/Startup.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using OpenIddict;
 using OpenIddict.Models;
 using openiddicttest.Models;
@@ -13,20 +11,6 @@ namespace openiddicttest
     public class Startup
     {
         public IConfigurationRoot Configuration { get; set; }
-
-        public static void Main(string[] args)
-        {
-            var application = new WebHostBuilder()
-                .ConfigureLogging(options => options.AddDebug(minLevel: LogLevel.Debug))
-                .ConfigureLogging(options => options.AddConsole(minLevel: LogLevel.Debug))
-                .UseDefaultHostingConfiguration(args)
-                .UseIISPlatformHandlerUrl()
-                .UseKestrel()
-                .UseStartup<Startup>()
-                .Build();
-
-            application.Run();
-        }
 
         public void ConfigureServices(IServiceCollection services)
         {
@@ -57,8 +41,6 @@ namespace openiddicttest
 
         public void Configure(IApplicationBuilder app, IDatabaseInitializer databaseInitializer)
         {
-            app.UseIISPlatformHandler();
-
             app.UseDeveloperExceptionPage();
 
             // to serve up index.html

--- a/src/openiddict-test/openiddict-test.xproj
+++ b/src/openiddict-test/openiddict-test.xproj
@@ -4,22 +4,15 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>f4d55d74-52c4-4575-be4d-9c92b35339b0</ProjectGuid>
     <RootNamespace>openiddict_test</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <DnxInvisibleContent Include="bower.json" />
-    <DnxInvisibleContent Include=".bowerrc" />
-    <DnxInvisibleContent Include="package.json" />
-  </ItemGroup>
-  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DotNet.Web\Microsoft.DotNet.Web.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/openiddict-test/project.json
+++ b/src/openiddict-test/project.json
@@ -1,44 +1,53 @@
 ﻿{
-  "version": "1.0.0-*",
-  "compilationOptions": {
+  "buildOptions": {
+    "debugType": "portable",
     "emitEntryPoint": true,
-    "preserveCompilationContext": true
+    "warningsAsErrors": true,
+    "preserveCompilationContext": true,
+
+    "copyToOutput": {
+      "include": [
+        "wwwroot",
+        "appsettings.json",
+        "web.config"
+      ]
+    }
   },
 
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-*",
-    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-*",
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0-*",
-    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0-*",
-    "Microsoft.AspNetCore.IISPlatformHandler": "1.0.0-*",
-    "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0-*",
-    "Microsoft.AspNetCore.Mvc": " 1.0.0-*",
-    "Microsoft.AspNetCore.Hosting": "1.0.0-*",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0-*",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0-*",
-    "AspNet.Security.OAuth.Validation": "1.0.0-*",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Authentication.JwtBearer": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.CommandLine": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
+    "AspNet.Security.OAuth.Validation": "1.0.0-alpha1-*",
     "OpenIddict.Core": "1.0.0-*",
     "OpenIddict.EF": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-*"
-  },
-
-  "commands": {
-    "web": "openiddict-test",
-    "ef": "EntityFrameworkCore.Commands"
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final"
   },
 
   "frameworks": {
     "net451": {
-      "frameworkAssemblies": {
-        "System.Runtime": { "type": "build", "version": "4.0.10.0" }
+      "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027"
       }
     },
 
-    "netstandardapp1.5": {
+    "netcoreapp1.0": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-*"
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-rc2-3002702"
+        }
       },
 
       "imports": [
@@ -48,13 +57,22 @@
     }
   },
 
-  "exclude": [
-    "wwwroot",
-    "node_modules"
-  ],
-  "publishExclude": [
-    "**.user",
-    "**.vspscc"
-  ]
+  "tools": {
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
+      "version": "1.0.0-preview1-final",
+      "imports": "portable-net45+wp80+win8+wpa81+dnxcore50"
+    }
+  },
 
+  "scripts": {
+    "postpublish": "dotnet publish-iis --publish-folder %publish:OutputPath% --framework %publish:FullTargetFramework%"
+  },
+
+  "publishOptions": {
+    "include": [
+      "wwwroot",
+      "appsettings.json",
+      "web.config"
+    ]
+  }
 }

--- a/src/openiddict-test/web.config
+++ b/src/openiddict-test/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" forwardWindowsAuthToken="false" stdoutLogEnabled="false" />
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
OpenIddict now uses the ASP.NET Core RC2 "CI release packages": https://github.com/openiddict/openiddict-core/pull/89/files.

This PR replaces the `aspnetcidev` feed by `aspnetcirelease` and pins all the versions to ensure RC3 packages or incompatible aspnet-contrib packages are never downloaded.

The final RC2 packages and the updated VS tooling should be available in the next few weeks. I'll send a PR to remove the `aspnetcirelease` feed and use the final packages when they are available on NuGet.org.

/cc @capesean 
