### PR TITLE
Use ApplicationRole in AddOpenIddict<> call

### DIFF
--- a/src/openiddict-test/Startup.cs
+++ b/src/openiddict-test/Startup.cs
@@ -29,7 +29,7 @@ namespace openiddicttest
                 .AddDefaultTokenProviders();
 
             // add OpenIddict
-            services.AddOpenIddict<ApplicationUser, ApplicationDbContext>()
+            services.AddOpenIddict<ApplicationUser, ApplicationRole, ApplicationDbContext>()
                 .AddTokenManager<CustomOpenIddictManager>()
                 .DisableHttpsRequirement()
                 .UseJsonWebTokens();


### PR DESCRIPTION
Fixes the error 

> Cannot create a DbSet for 'IdentityRole' because this type is not included in the model for the context.

When requesting a token with roles in its scope.

See the following issue: https://github.com/capesean/openiddict-test/issues/14
